### PR TITLE
Update container image for non-root ops

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,26 +2,17 @@ version: "3.9"
 
 services:
   react-native:
-    image: utkusarioglu/react-native-android-devcontainer:1.0.13
+    image: utkusarioglu/react-native-android-devcontainer:1.0.15
     volumes:
       - type: bind
         source: ..
         target: /utkusarioglu/trials/rn-18/android
-      # - type: bind
-      #   source: ../../hooks
-      #   target: /utkusarioglu/trials/rn-18/common
-      #   read_only: true
-      #   volume:
-      #     nocopy: true
       - type: volume
         source: ccache
         target: /ccache
       - type: volume
         source: gradle
-        target: /root/.gradle
-      # - type: volume
-      #   source: android-ndk
-      #   target: /opt/android/ndk/21.4.7075529/toolchains/llvm/prebuilt
+        target: /home/rn/.gradle
       - type: volume
         source: android
         target: /opt/android
@@ -31,9 +22,6 @@ volumes:
     name: react-native-ccache
   gradle:
     name: react-native-gradle
-
-  # android-ndk:
-  #   name: react-native-android-ndk-prebuilt
 
   android:
     name: react-native-android

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
         "panel": "dedicated",
         "showReuseMessage": false,
         "clear": true,
-        "close": false
+        "close": true
       }
     },
     {


### PR DESCRIPTION
Updates the docker image used in the repo to `1.0.15`. This new image 
uses a non-root user by default.

Updates the mount path for gradle to `/home/rn/.gradle` as this is
where the new image shall store its cache and gradle dependencies.

Alters the behavior of "WSA connect" task to close the window once
the command has been sent, WSA behavior signals to the user whether
the task has succeeded.
